### PR TITLE
Update docopt_.py due to traceback errors

### DIFF
--- a/clinto/parsers/docopt_.py
+++ b/clinto/parsers/docopt_.py
@@ -6,6 +6,7 @@ import json
 import imp
 import inspect
 import tempfile
+import traceback
 import six
 from collections import OrderedDict
 from itertools import chain


### PR DESCRIPTION
Reproducing:

```
Archons-MBP:Epsilon devy$ ./manage.py addscript ../../../Horizon.py 
Converting ../../../Horizon.py
Error while loading /Users/devy/Desktop/Development/tech-3/Epsilon/Epsilon/Epsilon/user_uploads/wooey_scripts/Horizon_U3M94tG.py:
Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/Library/Python/2.7/site-packages/django/core/management/__init__.py", line 351, in execute_from_command_line
    utility.execute()
  File "/Library/Python/2.7/site-packages/django/core/management/__init__.py", line 343, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Library/Python/2.7/site-packages/django/core/management/base.py", line 394, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/Library/Python/2.7/site-packages/django/core/management/base.py", line 445, in execute
    output = self.handle(*args, **options)
  File "/Library/Python/2.7/site-packages/wooey/management/commands/addscript.py", line 46, in handle
    res = add_wooey_script(script_path=script, group=group)
  File "/Library/Python/2.7/site-packages/wooey/backend/utils.py", line 227, in add_wooey_script
    parser = Parser(script_name=filename, script_path=local_storage.path(local_file))
  File "/Library/Python/2.7/site-packages/clinto/parser.py", line 18, in __init__
    parser_obj = [pc(script_path, script_source) for pc in parsers]
  File "/Library/Python/2.7/site-packages/clinto/parsers/base.py", line 38, in __init__
    self.extract_parser()
  File "/Library/Python/2.7/site-packages/clinto/parsers/docopt_.py", line 90, in extract_parser
    self.error = '{0}\n'.format(traceback.format_exc())
NameError: global name 'traceback' is not defined
```
